### PR TITLE
fix: cast variable with constructor instead of keyword

### DIFF
--- a/packages/faye_dart/lib/src/client.dart
+++ b/packages/faye_dart/lib/src/client.dart
@@ -152,7 +152,7 @@ class FayeClient with Extensible, TimeoutHelper, EquatableMixin {
   }
 
   void _onDataReceived(dynamic data) {
-    final json = jsonDecode(data) as List<Map<String, Object?>>;
+    final json = List<Map<String, Object?>>.from(jsonDecode(data));
     Iterable<Message>? messages;
     try {
       messages = json.map(Message.fromJson);


### PR DESCRIPTION
fix `Expected a value of type 'List<Map<String, Object?>>', but got one of type 'List<dynamic>'`